### PR TITLE
Fix zigbee2mqtt-hue-dimmer-v2 off_hold value

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-hue-dimmer-v2.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-hue-dimmer-v2.yaml
@@ -66,7 +66,7 @@ buttons:
       - title: hold
         conditions:
           - key: payload
-            value: 
+            value: off_hold
       - title: hold (released)
         conditions:
           - key: payload


### PR DESCRIPTION
zigbee2mqtt-hue-dimmer-v2.yaml is missing value for off button hold action and the blueprint fails to load with following error:

```
homeassistant  | 2023-01-02 17:44:32.641 ERROR (MainThread) [custom_components.switch_manager.const] ("Invalid config for [switch_manager blueprints(zigbee2mqtt-hue-dimmer-v2)]: string value is None for dictionary value @ data['buttons'][3]['actions'][1]['conditions'][0]['value']. Got None. (See ?, line ?). ", True)
```

Define the value to fix the issue.