### PR TITLE
Added hold (released) event to Z-WaveJS/Zooz Zen76

### DIFF
--- a/custom_components/switch_manager/blueprints/zwave-js-zooz-zen76.yaml
+++ b/custom_components/switch_manager/blueprints/zwave-js-zooz-zen76.yaml
@@ -39,6 +39,10 @@ buttons:
         conditions:
           - key: value
             value: KeyHeldDown
+      - title: hold (released)
+        conditions:
+          - key: value
+            value: KeyReleased
   - shape: rect
     x: 38
     y: 388
@@ -72,3 +76,7 @@ buttons:
         conditions:
           - key: value
             value: KeyHeldDown
+      - title: hold (released)
+        conditions:
+          - key: value
+            value: KeyReleased


### PR DESCRIPTION
Zooz Zen76 was missing the hold (released) event and it's pretty useful for advanced functionality. 

## Blueprint Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [x] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [x] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [x] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [x] Images are png
- [x] Image backgrounds are transparent and is cropped to the device boundries
- [x] Images has a maximum width of 800px and maximum height of 500px
- [x] There are no missing buttons or actions
- [x] Your integration/service is running on the latest version
- [x] You have tested your blueprints and made sure each button and action works

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->