### PR TITLE
Update zigbee2mqtt-ikea-e1812.yaml

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e1812.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e1812.yaml
@@ -8,6 +8,10 @@ buttons:
         conditions:
           - key: payload
             value: 'on'
+      - title: press 2x
+        conditions:
+          - key: payload
+            value: 'off'
       - title: hold
         conditions:
           - key: payload


### PR DESCRIPTION
Added existing double click functionality with E1812 & Zigbee2Mqtt (payload = "off")

## Blueprint Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [x] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [x] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [x] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [x] There are no missing buttons or actions
- [x] Your integration/service is running on the latest version
- [x] You have tested your blueprints and made sure each button and action works

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->