### PR TITLE
Add max-width to svg

### DIFF
--- a/js/switch-editor.ts
+++ b/js/switch-editor.ts
@@ -402,6 +402,7 @@ class SwitchManagerSwitchEditor extends LitElement
             #switch-image > svg {
                 /* for strokes on edge */
                 overflow: visible;
+                max-width: 800px;
             }
             #switch-image ha-svg-icon {
                 fill: var(--primary-color);


### PR DESCRIPTION
All uploaded images should not exceed the maximum width of 800px as stated below in the checklist. But in the UI, very wide images get upscaled to full browser width instead of being limited to 800px. 
I solved the problem for me by adding `max-width` to `#switch-image > svg` in `switch_manager_panel.js`. The result you can see in the screenshot below. But I don't know if that is the cleanest solution and I also don't know if changing that in the ts file is correct. If you have a better solution, feel free to close this PR.

Before:
![before](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager/assets/30938717/29a6ff4a-57ad-48bc-97ac-b933585fd89a)
After:
![image](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager/assets/30938717/6a72345a-f9a5-4a63-89e1-847c93cb93ba)

## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [ ] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [ ] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [ ] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [ ] Images are png
- [ ] Image backgrounds are transparent and is cropped to the device boundries
- [ ] Images has a maximum width of 800px and maximum height of 500px
- [ ] There are no missing buttons or actions
- [ ] Your integration/service is running on the latest version
- [ ] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [ ] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->