### PR TITLE
Correct service on Sunricher (K8)

### DIFF
--- a/custom_components/switch_manager/blueprints/zwave-js-k8.yaml
+++ b/custom_components/switch_manager/blueprints/zwave-js-k8.yaml
@@ -1,5 +1,5 @@
 name: Sunricher and various (K8)
-service: Z-wave JS
+service: Z-Wave JS
 event_type: zwave_js_value_notification
 identifier_key: node_id
 conditions:


### PR DESCRIPTION
Fix service type misspelling `Z-wave JS` -> `Z-Wave JS`

## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [x] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [x] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [x] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [x] Images are png
- [x] Image backgrounds are transparent and is cropped to the device boundries
- [x] Images has a maximum width of 800px and maximum height of 500px
- [x] There are no missing buttons or actions
- [x] Your integration/service is running on the latest version
- [x] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [x] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->