### PR TITLE
- Inovelli ZHA and Z2M blueprints can be used with VZM35-SN model

### DIFF
--- a/custom_components/switch_manager/blueprints/zha-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zha-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
@@ -1,4 +1,4 @@
-name: Inovelli VZM31-SN Blue Series 2-1 Switch
+name: Inovelli VZM31-SN or VZM35-SN Blue Series 2-1 Switch
 service: ZHA
 event_type: zha_event
 identifier_key: device_id

--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
@@ -1,4 +1,4 @@
-name: Inovelli VZM31-SN Blue Series 2-1 Switch
+name: Inovelli VZM31-SN or VZM35-SN Blue Series 2-1 Switch
 service: Zigbee2MQTT
 event_type: mqtt
 mqtt_topic_format: zigbee2mqtt/+/action


### PR DESCRIPTION
## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [x] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [x] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [x] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [x] Images are png
- [x] Image backgrounds are transparent and is cropped to the device boundries
- [x] Images has a maximum width of 800px and maximum height of 500px
- [x] There are no missing buttons or actions
- [x] Your integration/service is running on the latest version
- [x] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [x] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->

Simple clarification that Inovelli template can be used with two different models, rather than duplicating the entire template. No file name changes to avoid breaking changes to end-users.