### PR TITLE
Correct IKEA E1744 Z2M action keys

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e1744.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e1744.yaml
@@ -7,24 +7,24 @@ buttons:
       - title: press
         conditions:
           - key: payload
-            value: play_pause
+            value: toggle
       - title: press 2x
         conditions:
           - key: payload
-            value: skip_forward
+            value: brightness_step_up
       - title: press 3x
         conditions:
           - key: payload
-            value: skip_backward
+            value: brightness_step_down
       - title: rotate left
         conditions:
           - key: payload
-            value: rotate_left
+            value: brightness_move_down
       - title: rotate right
         conditions:
           - key: payload
-            value: rotate_right
+            value: brightness_move_up
       - title: rotate (stopped)
         conditions:
           - key: payload
-            value: rotate_stop
+            value: brightness_stop


### PR DESCRIPTION
## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [ ] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [ ] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [ ] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [ ] Images are png
- [ ] Image backgrounds are transparent and is cropped to the device boundries
- [ ] Images has a maximum width of 800px and maximum height of 500px
- [X] There are no missing buttons or actions
- [X] Your integration/service is running on the latest version
- [X] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [X] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->

Correct the issue #64, action keys previously on the blueprint were the ones with the `legacy` parameter set to `true` in Zigbee2mqtt.