### PR TITLE
Allow users to install last release

### DIFF
--- a/custom_components/switch_manager/manifest.json
+++ b/custom_components/switch_manager/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager/issues",
   "requirements": [],
-  "version": "1.3.2"
+  "version": "1.3.2-2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Switch Manager",
     "render_readme": true,
-    "homeassistant": "2023.12.0"
+    "homeassistant": "2023.12.0b0"
 }


### PR DESCRIPTION
Allow Home Assistant beta versions by appending b0. Without b0, only official releases will be allowed.

Check the docs at https://hacs.xyz/docs/publish/start#hacsjson.

Will also need a new GitHub release.
Closed #192.