### PR TITLE
Update the zigbee2mqtt-invoelli blueprint to use payload

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-inovelli-vzm31-sn-blue-series-2-1-switch.yaml
@@ -7,89 +7,89 @@ buttons:
     actions: # Up
       - title: press
         conditions:
-          - key: command
+          - key: payload
             value: up_single
       - title: press 2x
         conditions:
-          - key: command
+          - key: payload
             value: up_double
       - title: press 3x
         conditions:
-          - key: command
+          - key: payload
             value: up_triple
       - title: press 4x
         conditions:
-          - key: command
+          - key: payload
             value: up_quadruple
       - title: press 5x
         conditions:
-          - key: command
+          - key: payload
             value: up_quintuple
       - title: hold
         conditions:
-          - key: command
+          - key: payload
             value: up_held
       - title: hold (released)
         conditions:
-          - key: command
+          - key: payload
             value: up_release
   - d: "M 91 248 H 203 V 380 H 91 V 248"
     actions: # Down
       - title: press
         conditions:
-          - key: command
+          - key: payload
             value: down_single
       - title: press 2x
         conditions:
-          - key: command
+          - key: payload
             value: down_double
       - title: press 3x
         conditions:
-          - key: command
+          - key: payload
             value: down_triple
       - title: press 4x
         conditions:
-          - key: command
+          - key: payload
             value: down_quadruple
       - title: press 5x
         conditions:
-          - key: command
+          - key: payload
             value: down_quintuple
       - title: hold
         conditions:
-          - key: command
+          - key: payload
             value: down_held
       - title: hold (released)
         conditions:
-          - key: command
+          - key: payload
             value: down_release
   - d: "M 210 116 H 219 V 170 H 210 V 116"
     actions: # Config
       - title: press
         conditions:
-          - key: command
+          - key: payload
             value: config_single
       - title: press 2x
         conditions:
-          - key: command
+          - key: payload
             value: config_double
       - title: press 3x
         conditions:
-          - key: command
+          - key: payload
             value: config_triple
       - title: press 4x
         conditions:
-          - key: command
+          - key: payload
             value: config_quadruple
       - title: press 5x
         conditions:
-          - key: command
+          - key: payload
             value: config_quintuple
       - title: hold
         conditions:
-          - key: command
+          - key: payload
             value: config_held
       - title: hold (released)
         conditions:
-          - key: command
+          - key: payload
             value: config_release


### PR DESCRIPTION
Fix for zigbee2mqtt that uses a non-json payload, started looking at this in https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager/issues/40#issuecomment-1925383372

## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [ ] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [ ] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [ ] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [ ] Images are png
- [ ] Image backgrounds are transparent and is cropped to the device boundries
- [ ] Images has a maximum width of 800px and maximum height of 500px
- [ ] There are no missing buttons or actions
- [ ] Your integration/service is running on the latest version
- [ ] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [ ] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->