### PR TITLE
Use async_register_static_paths instead of register_static_path

### DIFF
--- a/custom_components/switch_manager/view.py
+++ b/custom_components/switch_manager/view.py
@@ -2,13 +2,12 @@ from .const import DOMAIN, CONF_BLUEPRINTS, BLUEPRINTS_FOLDER, PANEL_URL, NAME
 from .helpers import VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.components.frontend import async_register_built_in_panel
+from homeassistant.components.http import StaticPathConfig
 
 async def async_setup_view(hass: HomeAssistant):
-
-    hass.http.register_static_path(
-        PANEL_URL,
-        hass.config.path("custom_components/switch_manager/assets/switch_manager_panel.js"),
-    )
+    await hass.http.async_register_static_paths([
+        StaticPathConfig(PANEL_URL, hass.config.path("custom_components/switch_manager/assets/switch_manager_panel.js"), True)
+    ])
 
     await async_bind_blueprint_images(hass)
 
@@ -29,9 +28,16 @@ async def async_setup_view(hass: HomeAssistant):
     )
 
 async def async_bind_blueprint_images(hass: HomeAssistant):
+    static_paths = []
+    
     for key in hass.data[DOMAIN].get(CONF_BLUEPRINTS):
         if hass.data[DOMAIN].get(CONF_BLUEPRINTS)[key].has_image:
-            hass.http.register_static_path(
-                f'/assets/{DOMAIN}/{key}.png',
-                hass.config.path(f"{BLUEPRINTS_FOLDER}/{DOMAIN}/{key}.png"),
+            static_paths.append(
+                StaticPathConfig(
+                    f'/assets/{DOMAIN}/{key}.png',
+                    hass.config.path(f"{BLUEPRINTS_FOLDER}/{DOMAIN}/{key}.png"),
+                    True
+                )
             )
+            
+    await hass.http.async_register_static_paths(static_paths)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Switch Manager",
     "render_readme": true,
-    "homeassistant": "2023.12.0"
+    "homeassistant": "2024.7.0"
 }


### PR DESCRIPTION
I saw that you were unhappy about having to deal with the breaking changes in HA so I figured that I could fix this one as well.
This fixes #242

It also unfortunately bumps the minimum required version of home assistant to 2024.7, as `async_register_static_paths ` has been introduced with that version: https://github.com/home-assistant/core/commit/faa55de538210554aa1311ea343c618a3fdfa449