### PR TITLE
Update zigbee2mqtt-ikea-e2201.yaml

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e2201.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-ikea-e2201.yaml
@@ -18,7 +18,7 @@ buttons:
       - title: hold (released)
         conditions:
           - key: payload
-            value: brightness_stop_up
+            value: brightness_stop
   - x: 143
     y: 436
     width: 42
@@ -34,4 +34,4 @@ buttons:
       - title: hold (released)
         conditions:
           - key: payload
-            value: brightness_stop_down
+            value: brightness_stop


### PR DESCRIPTION
handle `brightness_stop` for ikea Rodret (E2201) cause the `brightness_stop_up` and `brightness_stop_down` are no more available
