### PR TITLE
Remove duplicate keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/Thumbs.db
 **/__pycache__/
 .vscode
+.DS_Store

--- a/custom_components/switch_manager/blueprints/zha-tuya-smart-knob-tz3000-abrsvsou.yaml
+++ b/custom_components/switch_manager/blueprints/zha-tuya-smart-knob-tz3000-abrsvsou.yaml
@@ -8,12 +8,6 @@
 # - rotate left
 # - rotate right
 
-name: TuYa 4 Button Scene
-service: ZHA
-event_type: zha_event
-identifier_key: device_id
-buttons:
-
 name: TuYa Smart Knob (_TZ3000_abrsvsou/TS004F)
 service: ZHA
 event_type: zha_event


### PR DESCRIPTION
HA 2025.4.1 gives a warning for duplicate keys for "name", "service", "event_type", identifier_key" and buttons". This small change removes the duplicate keys left to zha-tuya-smart-knob-tz3000-abrsvsou.yaml.


## Blueprint Checklist

<!--
  Put an `x` in the boxes that apply. Checkboxes should be marked without spaces eg. [x] and not [ x] or [x ] as the markdown won't render the checkboxes correctly if there are space within the brackets. Alternatively you can check the boxes through the UI after submitting the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [ ] You viewed the README and conformed to the [naming conventions](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#title-naming-convention)
- [ ] You ordered the actions as stated in the README [action order](https://github.com/Sian-Lee-SA/Home-Assistant-Switch-Manager#order-convention)
- [ ] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [ ] Images are png
- [ ] Image backgrounds are transparent and is cropped to the device boundries
- [ ] Images has a maximum width of 800px and maximum height of 500px
- [ ] There are no missing buttons or actions
- [ ] Your integration/service is running on the latest version
- [ ] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [ ] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?

<!--
  It is important to have the naming conventions and action ordering conformed while also ensuring all buttons and actions are supplied because any future changes will invalidate any blueprint for a user who uses your blueprint

  Thank you for contributing
-->